### PR TITLE
Bump commons-io:commons-io from 2.4 to 2.14.0 in /app

### DIFF
--- a/app/pom.xml
+++ b/app/pom.xml
@@ -89,7 +89,7 @@
 		<dependency>
 			<groupId>commons-io</groupId>
 			<artifactId>commons-io</artifactId>
-			<version>2.4</version>
+			<version>2.14.0</version>
 		</dependency>
 
 		<!-- Vuln Method libs -->


### PR DESCRIPTION
Bumps commons-io:commons-io from 2.4 to 2.14.0.

---
updated-dependencies:
- dependency-name: commons-io:commons-io dependency-type: direct:production ...